### PR TITLE
replace old docs pages with redirects to new ones

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,6 +2,14 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    
+    <!-- 
+      http://everypolitician.org/about.html (this page)
+      is now at http://docs.everypolitician.org/
+    -->
+    <meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/">
+    <link rel="canonical" href="http://docs.everypolitician.org/" />
+    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">
@@ -10,39 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script src="/javascript/modernizr.js"></script>
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
-    <script src="/javascript/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
-    <script src="/javascript/jquery.select-to-autocomplete.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-2.0.2.min.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-world-mill-en.js"></script>
-    <script src="/javascript/main.js"></script>
-    <meta property="og:title" content="EveryPolitician" />
-    <meta property="og:type" content="article" />
-    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:image:width" content="300" />
-    <meta property="og:site_name" content="EveryPolitician" />
-    <meta property="og:description" content="Data about every national legislature in the world, freely available for you to use.">
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@mysocietyIntl" />
-    <meta name="twitter:title" content="EveryPolitician" />
-    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="twitter:image:height" content="400" />
-    <meta property="twitter:image:width" content="400" />
-    <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />
     <title>EveryPolitician</title>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-660910-34', 'auto');
-      ga('send', 'pageview');
-    </script>
 </head>
 <body>
     <div id="wrapper">
@@ -64,130 +40,28 @@
                 <div class="site-header__navigation site-header__navigation--secondary">
                     <nav role="navigation">
                         <a href="/countries.html">Data</a>
-                        <a href="/about.html">About</a>
+                        <a href="http://docs.everypolitician.org/">Documentation</a>
                     </nav>
                 </div>
             </div>
         </header>
 
         <div class="site-content">
-            <div class="container" id="about">
-  <div class="page-section">
-    <div class="row">
-      <div class="column-one-quarter">
-         <ul class="unstyled-list">
-  <li><a href="about.html">What is EveryPolitician?</a></li>
-  <li><a href="data_summary.html">What’s in the data?</a></li>
-  <li><a href="contribute.html">How to contribute</a></li>
-  <li>Technical details:</li>
-  <li>
-      <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
-        <li><a href="data_structure.html">Data structure</a></li>
-        <li><a href="repo_structure.html">Getting most recent data</a></li>
-        <li><a href="use_the_data.html">Using the data</a></li>
-        <li><a href="submitting.html">How we import data</a></li>
-        <li><a href="scrapers.html">Writing a scraper</a></li>
-      </ul>
-  </li>
-</ul>
-      </div>
-      <div class="column-three-quarters">
-        <h1>What is EveryPolitician?</h1>
-        <p class="section-intro">
-          The clue’s in the name. EveryPolitician aims to provide data
-          about, well, every politician. In the world.
-        </p>
-        <p>
-          It’s a simple but ambitious project to collect and share that
-          data, in a consistent, open format that anyone can use.
-        </p>
-        <p>
-          Why? Because this resource doesn’t yet exist. And it would be
-          incredibly useful, for a huge number of people and organisations
-          all around the world.
-        </p>
-        <p>
-          When data is in a consistent, structured format, it can be reused
-          by developers everywhere. You don’t have waste time scraping data
-          and converting it into a format you can work with; instead, you
-          can simply concentrate on making tools. And those tools can more
-          easily be picked up, used and adapted to local needs anywhere in
-          the world, saving everyone time and effort. 
-        </p>
-
-        <h2>The data</h2>
-        <p>
-          The long term aim is to include every elected official in the
-          world, but let’s start simple. Our first goal is to have data for
-          all present-day national-level legislators.
-        </p>
-        <p>
-          To see how far we’ve got, <a href="/countries.html">pick a country</a>.
-        </p>
-        <p>
-          There’s more to this data than you’ll see there, though. For most
-          datasets there is richer information available, including contact
-          details, photos, gender, and more. 
-        </p>
-        <p>
-          If you want to use that data, you can download it in two useful formats:
-        </p>
-        <ul>
-          <li>
-            <abbr title="comma separated value">CSV</abbr> format (great for spreadsheets)
-          </li>
-          <li>
-            <abbr title="JavaScript Object Notation">JSON</abbr> in Popolo format (ideal for
-              developers)
-          </li>
-        </ul>
-        <div class="process-boxes">
-          <div class="step-1">
-            <p>
-              Want to start using it? Here's 
-              <a href="repo_structure.html">how to get the most recent data</a>.
-            </p>
-          </div>
-        </div>
-        <p>
-          A note about the Popolo standard: it’s a rich, expressive format that,
-          like a language, is used in many different ways by different authors.
-          However, when we add data to EveryPolitician we always use Popolo
-          according to the same, defined principles. It’s because of this
-          consistency that the tools you build will work with EveryPolitician data
-          from any country, for any country.
-        </p>
-        <p>
-          Want more detail? Interested in using this data in a web
-          application or tool you’re building? See the <a
-          href="/technical.html">technical overview of EveryPolitician</a>.
-        </p>  
-
-        <h2>How can I add or correct information?</h2>
-
-        <p>See our handy guide to <a href="/contribute.html">contributing</a>.
-
-        <h2 id="what-next">What next?</h2>
-
-        <p>In a way, that’s up to you. The data’s here, now go and build the tools to use it! (And don’t forget to let us know when you do.)</p>
-    
-        <p>We already know that EveryPolitician’s data will help with existing projects, like these ones which make it easy to 
-        <a href="http://sayit.poplus.org/">track what those politicians say</a>, or
-        <a href="http://www.cargografias.org/">visualise their political careers</a>, or
-        which enable citizens to <a href="http://writeit.poplus.org/">send public messages to them</a>. </p>
-
-        <p>As data becomes available from more countries, all in the same format,
-        more and more tools like this will become possible.</p>
-
-        <h2 id="find-out-more">Find out more</h2>
-
-        <p>EveryPolitician is a <a href="http://www.poplus.org/">Poplus</a> project. Drop by
-        our <a href="https://groups.google.com/forum/#!forum/poplus">friendly mailing list</a> 
-        to ask questions or just to say hello.</p>
-      </div>
+            <div class="hero hero--jazzy">
+    <div class="container">
+        <h1>About</h1>
     </div>
-  </div>
+</div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/data_structure.html" class="button button--secondary">Load page</a>
+        </p>
+    </div>
 </div>
 
         </div>

--- a/contribute.html
+++ b/contribute.html
@@ -2,6 +2,14 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    
+    <!-- 
+      http://everypolitician.org/contribute.html (this page)
+      is now at http://docs.everypolitician.org/contribute.html
+    -->
+    <meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/contribute.html">
+    <link rel="canonical" href="http://docs.everypolitician.org/contribute.html/" />
+    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">
@@ -10,39 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script src="/javascript/modernizr.js"></script>
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
-    <script src="/javascript/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
-    <script src="/javascript/jquery.select-to-autocomplete.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-2.0.2.min.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-world-mill-en.js"></script>
-    <script src="/javascript/main.js"></script>
-    <meta property="og:title" content="EveryPolitician" />
-    <meta property="og:type" content="article" />
-    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:image:width" content="300" />
-    <meta property="og:site_name" content="EveryPolitician" />
-    <meta property="og:description" content="Data about every national legislature in the world, freely available for you to use.">
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@mysocietyIntl" />
-    <meta name="twitter:title" content="EveryPolitician" />
-    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="twitter:image:height" content="400" />
-    <meta property="twitter:image:width" content="400" />
-    <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />
     <title>EveryPolitician</title>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-660910-34', 'auto');
-      ga('send', 'pageview');
-    </script>
 </head>
 <body>
     <div id="wrapper">
@@ -64,188 +40,30 @@
                 <div class="site-header__navigation site-header__navigation--secondary">
                     <nav role="navigation">
                         <a href="/countries.html">Data</a>
-                        <a href="/about.html">About</a>
+                        <a href="http://docs.everypolitician.org/">Documentation</a>
                     </nav>
                 </div>
             </div>
         </header>
 
         <div class="site-content">
-            <div class="container" id="contribute">
-  <div class="page-section">
-    <div class="row">
-      <div class="column-one-quarter">
-         <ul class="unstyled-list">
-  <li><a href="about.html">What is EveryPolitician?</a></li>
-  <li><a href="data_summary.html">What’s in the data?</a></li>
-  <li><a href="contribute.html">How to contribute</a></li>
-  <li>Technical details:</li>
-  <li>
-      <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
-        <li><a href="data_structure.html">Data structure</a></li>
-        <li><a href="repo_structure.html">Getting most recent data</a></li>
-        <li><a href="use_the_data.html">Using the data</a></li>
-        <li><a href="submitting.html">How we import data</a></li>
-        <li><a href="scrapers.html">Writing a scraper</a></li>
-      </ul>
-  </li>
-</ul>
-      </div>
-      <div class="column-three-quarters">
-        <h1>We need your help</h1>
-
-        <p class="section-intro">
-          EveryPolitician is an ambitious project. If we’re to succeed in our
-          aim of collecting and sharing data on every elected official in the
-          entire world, we need help from people like you.
-        </p>
-        <p>
-          Right now, we’re concentrating on making sure we have current data on
-          the national legislatures for every country in the world.
-        </p>
-        <h2>If your country is missing</h2>
-        <a name="process"></a>
-        <p>
-          Here are the three steps we follow to put a country on the
-          <a href="countries.html">EveryPolitician map</a>:
-        </p>
-        <div class="process-boxes">
-          <div class="step-0">
-            1. find the data somewhere on the web
-            <p>
-              That might simply be finding a list of politicians on the
-              parliament’s website, or knowing of a local group that already
-              collects this data.
-            </p>
-          </div>
-          <div class="step-1">
-            2. turn that into a format we can import
-            <p>
-              Often that means running a scraper that gets the data off the
-              webpage and turns it into the kind of data we can easily import
-              (or, if we’re lucky, doing next to nothing because it’s already
-              in a lovely format).
-            </p>
-          </div>
-          <div class="step-2">
-            3. pull it into EveryPolitician
-            <p>
-              We add it to the project by telling EveryPolitician where the
-              importable data is, and how to merge it in.
-            </p>
-          </div>
-        </div>
-
-        <p>
-          Have a look at the list of
-          <a href="needed.html">countries we don’t
-          have data for yet</a>.
-        </p>
-        <p>
-          If a country is listed under &ldquo;<strong>Source
-          needed</strong>&rdquo; then it’s still at step 1 of the process. If
-          you know where there is comprehensive poltician data for that
-          country, please let us know!
-        </p>
-        <p>
-          Incidentally, there may be more than one source for a given country’s
-          data. Ideally, everything is in one place. However, things are often
-          more complicated than that, so one site might have all the
-          politician’s names and party memberships, but a different site has
-          their twitter handles. But that’s OK because we’re happy to merge
-          different sources.
-        <p>
-        <p>
-          If a country appears under &ldquo;<strong>Scraper
-          needed</strong>&rdquo; it means that we do have at least one source
-          for the data, but so far nobody has turned that data into <a
-          href="submitting.html">a format we can easily import</a> &mdash; this
-          is waiting at step 2. It will be on our list of things to do (in
-          fact, you should see it as an
-          <a href="https://github.com/everypolitician/everypolitician-data/issues?q=is%3Aopen+label%3A%22To+Find%22++label%3A%22New+country%22+">issue
-          on GitHub</a>).
-        </p>
-        <p>
-          If we’re very lucky the data identified in the source is already in a
-          lovely format, and we can move straight to step 3. That’s very rare,
-          though, so normally the data will need to be taken off the web pages
-          it’s on and turned into easy-to-import data. That’s what the scrapers
-          do, and we basically have one for every country whose data is in
-          EveryPolitician.
-        </p>
-        <p>
-          If you’re a developer and you fancy writing such a scraper, we’d be
-          stupendously grateful. We’ve written some <a
-          href="scrapers.html">guidelines about writing scrapers</a> to help
-          you (depending on how complex or clean the source data, it might be
-          easier &mdash; and more fun! &mdash; than you think).
-        </p>
-        <p>
-          Once the data’s in a suitable format, we’ll add it to
-          EveryPolitician’s list of scrapers (what this really means is making
-          the Rake tasks aware of where to get the formatted data, and how to
-          merge it all together). That’s step 3 and we’ll take care of that for
-          you.
-        </p>
-        <p>
-          In summary, if you:
-        </p>
-        <ul>
-          <li>
-            know where there’s a missing source for a country we’re currently lacking
-          </li>
-          <li>
-            have some or all of the data we’re looking for, or can put us in
-            touch with a group who has it, or even just know where we can find
-            it in a reasonably well-structured form
-          </li>
-          <li>
-            or want to write a scraper for one of the countries we haven’t done yet
-          </li>
-        </ul>
-        <p>
-          ...then please send an email to
-          <a
-          href="mailto:team@everypolitician.org">team@everypolitician.org</a>
-          and tell us!
-        </p>
-
-        <h2>If you see an error in the data</h2>
-
-        <p>Found something incorrect in the data we’re currently displaying on the site?</p>
-
-        <p>We’re working on building tools to let you edit the data directly,
-        but in the meantime, if you see an error that should be corrected,
-        email us at <a href="mailto:team@everypolitician.org">team@everypolitician.org</a>.</p>
-
-        <p>Please include evidence for your proposed change — a link to an
-        official source, where possible.</p>
-
-        <h2>If there are gaps in the data</h2>
-
-        <p>At this early stage, we’re focusing on making sure we have basic
-        information about the current legislators in every country: names,
-        contact details, political parties, and the areas they represent.
-        Please help us gather that if you can.</p>
-
-        <p>Covering every current legislature is our primary goal right now,
-        but it’s always great when we can obtain past information too. See,
-        for example, <a href="/greenland/">the data for Greenland</a>, which
-        contains data on every Member since the formation of its current
-        Parliament in 1979.</p>
-
-        <h2>Looking for different data?</h2>
-
-        <p>In this initial phase, we’re only collecting information about <a
-        href="https://en.wikipedia.org/wiki/List_of_legislatures_by_country">country-level
-        Parliaments and Congresses</a>. Eventually we hope that much more than
-        this will be available, but having every national legislature would be a
-        great first step.</p>
-      </div>
+            <div class="hero hero--jazzy">
+    <div class="container">
+        <h1>Contributing</h1>
     </div>
-  </div>
 </div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/contribute.html">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/data_structure.html" class="button button--secondary">Load page</a>
+        </p>
+    </div>
+</div>
+
         </div>
 
         <footer class="site-footer ms-footer">

--- a/data_structure.html
+++ b/data_structure.html
@@ -2,6 +2,14 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    
+    <!-- 
+      http://everypolitician.org/data_structure.html (this page)
+      is now at http://docs.everypolitician.org/data_structure.html
+    -->
+    <meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/data_structure.html">
+    <link rel="canonical" href="http://docs.everypolitician.org/data_structure.html/" />
+    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">
@@ -10,39 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script src="/javascript/modernizr.js"></script>
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
-    <script src="/javascript/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
-    <script src="/javascript/jquery.select-to-autocomplete.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-2.0.2.min.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-world-mill-en.js"></script>
-    <script src="/javascript/main.js"></script>
-    <meta property="og:title" content="EveryPolitician" />
-    <meta property="og:type" content="article" />
-    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:image:width" content="300" />
-    <meta property="og:site_name" content="EveryPolitician" />
-    <meta property="og:description" content="Data about every national legislature in the world, freely available for you to use.">
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@mysocietyIntl" />
-    <meta name="twitter:title" content="EveryPolitician" />
-    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="twitter:image:height" content="400" />
-    <meta property="twitter:image:width" content="400" />
-    <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />
     <title>EveryPolitician</title>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-660910-34', 'auto');
-      ga('send', 'pageview');
-    </script>
 </head>
 <body>
     <div id="wrapper">
@@ -64,242 +40,28 @@
                 <div class="site-header__navigation site-header__navigation--secondary">
                     <nav role="navigation">
                         <a href="/countries.html">Data</a>
-                        <a href="/about.html">About</a>
+                        <a href="http://docs.everypolitician.org/">Documentation</a>
                     </nav>
                 </div>
             </div>
         </header>
 
         <div class="site-content">
-            <div class="container" id="about">
-  <div class="page-section">
-    <div class="row">
-      <div class="column-one-quarter">
-         <ul class="unstyled-list">
-  <li><a href="about.html">What is EveryPolitician?</a></li>
-  <li><a href="data_summary.html">What’s in the data?</a></li>
-  <li><a href="contribute.html">How to contribute</a></li>
-  <li>Technical details:</li>
-  <li>
-      <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
-        <li><a href="data_structure.html">Data structure</a></li>
-        <li><a href="repo_structure.html">Getting most recent data</a></li>
-        <li><a href="use_the_data.html">Using the data</a></li>
-        <li><a href="submitting.html">How we import data</a></li>
-        <li><a href="scrapers.html">Writing a scraper</a></li>
-      </ul>
-  </li>
-</ul>
-      </div>
-      <div class="column-three-quarters">
-
+            <div class="hero hero--jazzy">
+    <div class="container">
         <h1>About EveryPolitician’s Data</h1>
-
-        <p class="lead">EveryPolitician’s data is not complete. It doesn’t yet cover every
-        nation in the world. We’re working on that (and 
-        <a href="/contribute.html">you can help too!</a>). </p>
-
-        <p>In creating EveryPolitician, we’ve made some decisions about what it
-        will — and what it won’t — try to provide. This page explains how and why
-        we made those decisions.</p>
-
-        <h2>Consistent and useful</h2>
-
-        <p>EveryPolitician’s goal is to provide basic data on every politician in
-        every national-level legislature in the world, in a <em>consistent and
-        useful</em> format.</p>
-
-        <p>The word "consistent" is important, and we use it in a very specific way:</p>
-
-        <ul>
-          <li>We aim to use appropriate standards where possible (particularly 
-            <a href="http://www.popoloproject.com/">Popolo</a>)</li>
-          <li>We try to follow clear conventions about how data within and beyond 
-            those standards are expressed</a></li>
-        </ul>
-
-        <p>With this in mind, EveryPolitician will only provide data that we’re
-        confident can be expressed in the same manner across the majority of
-        national legislatures. This means there’s useful and interesting data
-        we’re deliberately choosing to not include yet, and some that we
-        probably never will.</p>
-
-        <p>Because we’re being very careful about what data we’re including, and
-        exactly what format it will be presented in, you can be very clear what
-        data you can — and cannot — expect to find here, and if you use it, you
-        won’t need to spend so much time dealing with lots of exceptional
-        cases.</p>
-
-        <p>(NB: Because some of this data was supplied by other people, we can’t
-        yet completely guarantee that the format for every country is completely
-        identical yet. But we’re actively working on fixing that, so if you find
-        something unexpected, please let us know!)</p>
-
-        <h2>Why we’re doing this</h2>
-
-        <p>We want to make it much easier for people to get started when building
-        civic tech tools.</p>
-
-        <p>Rather than having to start by finding data and turning that into a
-        usable format — a process that can be deceptively tricky, especially if
-        your tool needs to work across multiple countries — we can provide the
-        initial data so you can concentrate on adding value on top of that.</p>
-
-        <p>In many cases the data EveryPolitician provides won’t be enough for
-        what you need — you’ll need to combine it with other information
-        locally. </p>
-
-        <p>But you should be able to get started much more quickly, and by using
-        data in the same consistent format that lots of other groups use
-        worldwide, any tools you build for one country are likely to work much
-        more easily in other countries too.</p>
-
-        <p>This is part of the <a href="http://poplus.org">Poplus federation</a>’s
-        mission of building and sharing re-usable civic tech. In fact, this project
-        has come about based on our experience of working with code and data reuse
-        <a href="https://www.mysociety.org/about/mysociety-around-the-world/">across
-        many countries worldwide</a>.</p>
-
-        <h2>What data we provide</h2>
-
-        <p>Put most simply, EveryPolitician data is primarily a list of data
-        about <em>people</em>. Those people must be members of a specific legislature
-        (for example, your country’s current parliament).</p>
-
-        <p>Those people may be members of <a href="https://en.wikipedia.org/wiki/Parliamentary_group">factions or parties</a>, 
-        and represent particular <a href="https://en.wikipedia.org/wiki/Electoral_district">districts or constituencies</a>, 
-        so we provide some information about those too.</p>
-
-        <p>There are two distinct types of information provided:</p>
-
-        <ol>
-          <li><p><strong>Entity data</strong></p></li>
-          <li><p><strong>Relationship data</strong></p></li> 
-        </ol>
-
-        <h3>Entity data</h3>
-
-        <p>When we provide details about a Poltician, Political Group/Party,
-        Constituency/District, or Legislative Period/Term, we adhere to the
-        equivalent <a href="http://popoloproject.com/">Popolo Project specification</a>
-        (as a <a href="http://www.popoloproject.com/specs/person.html">Person</a>,
-        <a href="http://www.popoloproject.com/specs/organization.html">Organization</a>,
-        <a href="http://www.popoloproject.com/specs/area.html">Area</a>, and
-        <a href="http://www.popoloproject.com/specs/event.html">Event</a>)</p>
-
-        <p>Popolo defines these entities very well, although we make a few
-        extensions to include fields that are not yet standardised, and we
-        plan to tighten things up where there are multiple ways to include the
-        same information.</p>
-
-        <h3>Relationship data</h3>
-
-        <p>Not every politician is in EveryPolitician (yet). We’re currently
-        limiting it to members of national-level legislatures
-        (Parliament/Congress/Assembly).</p>
-
-        <p>So, for now, the only Relationship information we provide is the
-        Membership of that Legislature. Popolo has not (yet?) standardised how
-        to model things like this, and unfortunately we’ve seen many different,
-        and largely mutually-exclusive, approaches to that, making it very
-        difficult to write tools that can operate on this sort of
-        information.</p>
-
-        <p>So we consistently express all such memberships as a Popolo
-        <a href="http://www.popoloproject.com/specs/membership.html">Membership</a> with the
-        following fields:</p>
-
-        <ul>
-          <li> <p><code>person</code>: the politician (Person)</p> </li>
-          <li> <p><code>organization</code>: the Legislature itself (Organization)</p> </li>
-          <li> <p><code>on_behalf_of</code>: the Parliamentary Group (faction, party) they are a member of (Organization)</p> </li>
-          <li> <p><code>area</code>: the district or constituency, where appropriate (Area)</p> </li>
-          <li> <p><code>legislative_period</code>: the Term of office (Event)</p> </li>
-          <li> <p><code>start_date</code> and/or <code>end_date</code> (if these differ from the start or end of the Term)</p> </li>
-        </ul>
-
-        <p>(People familiar with Popolo might wonder why we don’t use
-        <a href="http://www.popoloproject.com/specs/post.html">Posts</a> here. 
-        Posts <em>can</em> be useful in some contexts, but in our experience
-        we’ve found that they only really work well in places with single-member
-        constituencies, and we believe that the simplicity of having every
-        legislature expressed in exactly the same way is much more valuable than
-        the benefits of sometimes using Posts.)</p>
-
-        <h3>What we don’t provide (and why)</h3>
-
-        <p>There is lots of other very valuable data available on politicians
-        worldwide, and eventually we hope to include much more.</p>
-
-        <p>But for now we don’t include anything other than the above — no asset
-        declarations, no memberships of corporate boards, or parliamentary
-        committees, or ministerial positions, etc.</p>
-
-        <p>Of course we’re not saying that this data isn’t important — far from
-        it! — just that we haven’t yet worked out how to provide it in
-        a way that is consistent and comparable across all national
-        jurisdictions.</p>
-
-        <p>As standards or conventions appear around these things, we’ll start
-        to include them, but for now we believe it’s much more important to
-        start with data that can be consistent everywhere.</p>
-
-        <h4>Wait! EveryPolitician doesn’t tell me who’s President/Prime Minister/Premier?</h4>
-
-        <p>That’s right – because that’s a role in the <em>executive</em> branch of
-        government, not the <em>legislative</em> branch — and for now we’re only
-        providing legislative information.</p>
-
-        <p>In some countries, the head of the government <em>is</em> also member
-        of the legislature, and if so they’ll appear in the data — but simply in
-        the same manner as any other member.</p>
-
-        <h4>Why don’t you just add a field for “is_leader”, or add an Organisation for the Cabinet?</h4>
-
-        <p>Yes: we’ve seen people do both of these things — and other things too. And
-        this is an excellent example of why it’s important that data doesn’t solely adhere
-        to a <strong>standard</strong>, but also that it’s <strong>consistent</strong>. 
-
-        <p>We’ve seen about six or seven different ways that some of these
-        things can be expressed, all in perfectly valid Popolo.</p>
-
-        <p>Within the context of a single country, each of them makes perfect sense. But
-        because they’re all different, any third-party tool needs to understand
-        how <em>all</em> of them are modelled if it wants to be able to do
-        something with data from multiple different sources.</p>
-
-        <p>So we aren’t going to add fields like this until someone works out
-        the best way to do it — in a manner that can work the same way pretty
-        much everywhere, and can cope with all the complexity and idiosyncrasies
-        of all the different ways countries worldwide organise their
-        governance.</p>
-
-        <p>If you know how to do that, great! Start a discussion about it on the <a
-        href="https://github.com/popolo-project/popolo-spec/issues/new">Popolo
-        tracker</a>, and once there’s consensus we’ll look at adding it.</p>
-
-        <h4>But doesn’t that make this data incomplete?</h4>
-
-        <p>Yes it is incomplete, but it’s <em>consistent and useful</em>. 
-
-        <p>We’re providing a <em>base data set</em> that you can build on. Just
-        because <em>our</em> data doesn’t include a field for who the President
-        is, that doesn’t mean that your application can’t store that
-        separately.</p>
-
-        <h4>But I already have complete, rich data for my country’s representatives.</h4>
-
-        <p>You probably don’t need EveryPolitician’s data then. But you could
-        help others.<p>
-
-        <p>Let us know (at team@everypolitician.org) what data you have, and
-        we’ll work with you to transform it into the EveryPolitician Popolo
-        format so that everyone else can benefit from it too.</p>
-
-      </div>
     </div>
-  </div>
+</div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/data_structure.html">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/data_structure.html" class="button button--secondary">Load page</a>
+        </p>
+    </div>
 </div>
 
         </div>

--- a/data_summary.html
+++ b/data_summary.html
@@ -2,6 +2,14 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    
+    <!-- 
+      http://everypolitician.org/data_summary.html (this page)
+      is now at http://docs.everypolitician.org/data_summary.html
+    -->
+    <meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/data_summary.html">
+    <link rel="canonical" href="http://docs.everypolitician.org/data_summary.html/" />
+    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">
@@ -10,39 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script src="/javascript/modernizr.js"></script>
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
-    <script src="/javascript/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
-    <script src="/javascript/jquery.select-to-autocomplete.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-2.0.2.min.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-world-mill-en.js"></script>
-    <script src="/javascript/main.js"></script>
-    <meta property="og:title" content="EveryPolitician" />
-    <meta property="og:type" content="article" />
-    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:image:width" content="300" />
-    <meta property="og:site_name" content="EveryPolitician" />
-    <meta property="og:description" content="Data about every national legislature in the world, freely available for you to use.">
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@mysocietyIntl" />
-    <meta name="twitter:title" content="EveryPolitician" />
-    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="twitter:image:height" content="400" />
-    <meta property="twitter:image:width" content="400" />
-    <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />
     <title>EveryPolitician</title>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-660910-34', 'auto');
-      ga('send', 'pageview');
-    </script>
 </head>
 <body>
     <div id="wrapper">
@@ -64,352 +40,28 @@
                 <div class="site-header__navigation site-header__navigation--secondary">
                     <nav role="navigation">
                         <a href="/countries.html">Data</a>
-                        <a href="/about.html">About</a>
+                        <a href="http://docs.everypolitician.org/">Documentation</a>
                     </nav>
                 </div>
             </div>
         </header>
 
         <div class="site-content">
-            <div class="container" id="about">
-  <div class="page-section">
-    <div class="row">
-      <div class="column-one-quarter">
-         <ul class="unstyled-list">
-  <li><a href="about.html">What is EveryPolitician?</a></li>
-  <li><a href="data_summary.html">What’s in the data?</a></li>
-  <li><a href="contribute.html">How to contribute</a></li>
-  <li>Technical details:</li>
-  <li>
-      <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
-        <li><a href="data_structure.html">Data structure</a></li>
-        <li><a href="repo_structure.html">Getting most recent data</a></li>
-        <li><a href="use_the_data.html">Using the data</a></li>
-        <li><a href="submitting.html">How we import data</a></li>
-        <li><a href="scrapers.html">Writing a scraper</a></li>
-      </ul>
-  </li>
-</ul>
-      </div>
-      <div class="column-three-quarters">
+            <div class="hero hero--jazzy">
+    <div class="container">
         <h1>What’s in EveryPolitician’s data?</h1>
-        <p class="section-intro">
-          Short answer: names. And dates of birth, twitter handles, political
-          group memberships, email addresses, honorific titles, image URLs, and
-          all sorts of useful things — all provided we can find them. How
-          complete this data is depends on the sources that people around the
-          world have found for us for each country.
-        </p>
-        <p>
-          This is an overview of what you can find in our data. You might also
-          want to read about the <a href="technical.html">two data formats
-          available</a> (CSV or JSON), and how the <a
-          href="data_structure.html">data structure</a> encapsulates
-          <strong>entities</strong> and <strong>relationships</strong>.
-        </p>
-        <p>
-          The CSV files, which are often easier to work with, contain a useful
-          distillation of what’s in the JSON. The fields that are used below to
-          describe the data appear as column headings in the CSV; the same data
-          will always be present in the JSON too, but in a more structured and
-          often richer form. For example, where the CSV file may contain one
-          <code>name</code> for a politician, the JSON data might also include
-          variations under <code>other_names</code>, mapped by language code.
-          The JSON often includes more detailed membership information too,
-          such as start and end dates, and so on. It will usually contain URLs
-          for the sources of our data.
-        </p>
-        <p>
-          Determine the <em>actual</em> names of the folders and files by
-          looking in the <code>data/</code> folder, or inside the
-          <a href="repo_structure.html">index file, <code>countries.json</code></a>.
-        </p>
-        <div class="nested-boxes">
-          <div class="odd-nest">
-            <ul>
-              <li>
-                folders for each <strong>country</strong>
-                <br>
-                e.g., <code>Algeria/</code>, <code>American_Samoa/</code>, <code>Albania/</code>
-              </li>
-            </ul>
-            <div>
-              <ul>
-                <li>
-                  folders for each <strong>legislature</strong>
-                  <br>
-                  e.g., <code>Assembly/</code>, <code>House/</code>, <code>Senate/</code>
-                  (many countries only have one)
-                </li>
-              </ul>
-              <div class="odd-nest">
-                <ul>
-                  <li>
-                    JSON file (Popolo format) of all data
-                    (<strong>terms</strong>, <strong>groups</strong>, <strong>persons</strong>)
-                    <br>
-                    e.g., <code>ep-popolo-v1.0.json</code>
-                  </li>
-                </ul>
-                <ul>
-                  <li>
-                    CSV file for each <strong>term</strong> containing <strong>persons</strong>:
-                    <br>
-                    e.g., <code>term-19.csv</code>, <code>term-2011.csv</code>, <code>term-1999-02-16.csv</code>
-                    <br>
-                    (in practice, if there’s only one term available, it’ll typically be the current one)
-                    <br>
-                    &nbsp;
-                    <div>
-                    <table class="definition">
-                      <tr>
-                        <td><strong>CSV field</strong></td>
-                        <td><strong>use &amp; example value</strong></td>
-                      </tr>
-                      <tr>
-                        <th>id</th>
-                        <td>
-                          unique within EveryPolitician
-                          <em>for this politician</em> (so you can use it to track
-                          people across terms, for example)
-                          <br>
-                          It’s a <a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</a>,
-                          and looks like
-                          <br><code>2bc9cc09-a33a-42d9-89c3-14effb20b8b0</code>
-                        </td>
-                      </tr>
-                      <tr>
-                        <th>name</th>
-                        <td>
-                          common name for this politician: <code>Anne Example</code>
-                          <br>See <a href="#about-names">more about names</a>
-                        </td>
-                      </tr>
-                      <tr>
-                        <th>sort_name</th>
-                        <td>name for sort ordering: <code>Example, Anne</code></td>
-                      </tr>
-                      <tr>
-                        <th>email</th>
-                        <td>email address: <code>anne@example.com</code></td>
-                      </tr>
-                      <tr>
-                        <th>twitter</th>
-                        <td>twitter handle: <code>example</code> (for <code>@example</code>)</td>
-                      </tr>
-                      <tr>
-                        <th>facebook</th>
-                        <td>Facebook name: <code>AnneExample</code> (for <code>facebook.com/AnneExample)</code>
-                      </tr>
-                      <tr>
-                        <th>group</th>
-                        <td>name of political group <code>Example Faction</code></td>
-                      </tr>
-                      <tr>
-                        <th>group_id<span class="superscript">&dagger;</span></th>
-                        <td>id for group</td>
-                      </tr>
-                      <tr>
-                        <th>area</th>
-                        <td>name of area represented <code>Example County</code></td>
-                      </tr>
-                      <tr>
-                        <th>area_id<span class="superscript">&dagger;</span></th>
-                        <td>id for area</td>
-                      </tr>
-                      <tr>
-                        <th>term<span class="superscript">&dagger;</span></th>
-                        <td>id or index for term</td>
-                      </tr>
-                      <tr>
-                        <th>start_date</th>
-                        <td>start of membership (if needed) <code>2010-11-29</code></td>
-                      </tr>
-                      <tr>
-                        <th>end_date</th>
-                        <td>end of membership (if needed) <code>2012-07-14</code></td>
-                      </tr>
-                      <tr>
-                        <th>image</th>
-                        <td>URL to image file <code>http://example.com/example.jpg</code></td>
-                      </tr>
-                      <tr>
-                        <th>gender</th>
-                        <td>gender if known <code>male</code> or <code>female</code></td>
-                      </tr>
-                    </table>
-                  </div>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-        <p>
-          <span class="superscript">&dagger;</span>
-          You can consider fields marked &dagger; as identifiers that are
-          unique within this legislature (unlike <code>id</code> itself, which
-          identifies the politician within <em>all</em> of EveryPolitician’s data). For
-          example, all politicians in this legislature with the same
-          <code>area_id</code> are representing the same area (which is what
-          you’d expect). Where appropriate, the actual value might be a useful
-          value. For example, for <code>area_id</code> we like to use <a
-          href="http://opencivicdata.readthedocs.org/en/latest/ocdids.html">Open
-          Civic Data IDs</a> like this:
-          <code>ocd-division/country:us/state:ca/cd:47</code>, but if no such
-          mapping is available from our sources, we’ll probably use a slug like
-          <code>area-foo-county</code>. If you can suggest better values
-          whenever you find us using our own ones, please get in touch!
-        </p>
-        <h2>
-          Legislatures and terms
-        </h2>
-        <p>
-          For every country, we break the data down into
-          <strong>legislatures</strong> (for example, the “parliament” or
-          “congress” of the country). Currently, we’re only working with
-          national, that is, top-level, legislatures. In the future we might
-          include local or state-level legislatures too.
-        </p>
-        <p>
-          Many countries have a single legislature. Some have two. For example,
-          the <a
-          href="http://everypolitician.org/united-states-of-america/">United
-          States of America</a> has the <em>House of Representatives</em> and
-          the <em>Senate</em>.
-        </p>
-        <p>
-          Furthermore, we split the data for those down into
-          <strong>terms</strong>. Like legislatures themselves, the way this
-          works may vary from country to country. Terms have a start and end
-          date, and the data therefore describes the membership of the
-          legislation during that period. In most democracies, new terms begin
-          after every national election.
-        </p>
-        <p>
-          This is pragmatic because we know online services and sites are
-          likely to be concerned with the country’s <em>current</em>
-          legislature, which means the data for politicians in the current
-          term. Often — but not always — this is also the data we’re most
-          likely to be able to source online, so if you see a country only has
-          one term in its data, it will probably be the most recent one. We’re
-          always interested in adding historic data too (that is, data for
-          previous terms), so if you know where we can get it for your country,
-          please let us know. Similarly, if we are lacking the current term
-          (maybe there’s just been an election?), please let us know — it might
-          be that our source has been updated and we haven’t pulled down the
-          latest changes.
-        </p>
-        <h2>
-          Politicians
-        </h2>
-        <p>
-          <strong>The richness of the data we have will depend on the source or
-          sources from which we’re getting it.</strong> We use a wide variety
-          of sources, some official and many more that are not. Indeed, the
-          EveryPolitician project exists partly because in many places it’s
-          still depressingly hard to get even basic information, such as who all
-          the current legislators are.
-        </p>
-        <p>
-          So the absolute minimum data we need for a politician to be in
-          EveryPolitician is their <strong>name</strong> (by implication, we
-          also have their membership of the legislature and its term). Unless
-          the system they are in does not use such mechanisms, we also try to
-          have the <strong>area</strong> they represent, and the
-          <strong>group</strong> (perhaps a party or faction) they belong to.
-          There may also be start and end dates if we know they did not serve
-          the full term.
-        </p>
-        <a name="about-names"></a>
-        <h3>
-          About names
-        </h3>
-        <p>
-          Names are a key part of any data set based around people. In the
-          basic CSV, the <code>name</code> will be the common name that we’ve
-          got from the source, but we’re aware that names are not quite that
-          simple. So we sometimes have separate fields for:
-        </p>
-        <p>
-          <code>name</code>
-          <code>given_name</code>
-          <code>family_name</code>
-          <code>honorific_prefix</code>
-          <code>honorific_suffix</code>
-          <code>patronymic_name</code>
-          <code>sort_name</code>
-        </p>
-        <p>
-          The JSON data includes <code>other_names</code>, which may contain
-          aliases as well as names for the politician in different languages.
-        </p>
-        <h3>
-          If you <em>only</em> want names
-        </h3>
-        <p>
-          For convenience, we isolate all the names of all the politicians
-          within each legislature and make them available in their own file.
-          (Like other files, look inside <code>countries.json</code> to find
-          its path and filename; in this case under <code>names</code>). This
-          file contains <code>name</code> and <code>id</code> fields. Note that
-          there may be more than one name for each politician (for example, we
-          might have the name of a Welsh politician rendered in English and
-          Chinese). If you need to consolidate them, use the <code>id</code> to
-          match them (or dive into the JSON data instead).
-        </p>
-        <p>
-          In fact, we’ve even built an external service that puts all these
-          names (together with identifier fields, such as <code>id</code>) into
-          a single CSV file (caution: that currently contains well over 80,000
-          names and growing): see
-          <a href="https://github.com/everypolitician/everypolitician-names/">everypolitician-names</a>.
-        </p>
-        <h3>
-          IDs to other data sets, including Wikidata
-        </h3>
-        <p>
-          We give each politician in EveryPolitician a unique ID (actually a
-          UUID). It’s keyed as <code>id</code> in the CSV. But often we’ll know
-          useful IDs for the same politician in other data sets too. You can
-          find these in the JSON data under <code>identifiers</code>.
-        </p>
-        <p>
-          Each identifier consists of an (<code>identifier</code>,
-          <code>scheme</code>) pair. For example, here’s an entry for the
-          identifier in Wikidata (the database behind Wikipedia):
-        </p>
-        <pre>
-"identifiers": [
-  {
-    "identifier": "Q3785077",
-    "scheme": "wikidata"
-  }
-]
-</pre>
-        <p>
-          (Incidentally, you can view Wikidata entries like this:
-          <a href="https://www.wikidata.org/wiki/Q3785077">wikidata.org/wiki/Q3785077</a>,
-          or using <a href="https://tools.wmflabs.org/reasonator/?q=Q3785077">the Reasonator</a>.
-          This example is Estonian politician Taavi Rõivas.)
-        <p>
-          We do this for other entities (such as legislatures themselves; and
-          we’re adding external identifiers for political parties or factions
-          too) as well as politicians. Remember that external data sets might
-          not be complete, so it’s possible to have a useful identifier which
-          isn’t populated for <em>all</em> records. For example, Wikidata only
-          holds data for entries that satisfy their “notability” criteria.
-        </p>
-        <p>
-          Some legislatures have adopted the good practice of assigning unique
-          IDs to their politicians, which can be useful when using their
-          official APIs. If you know that your country’s legistature provides
-          such IDs please tell us, and we’ll add them as identifiers in this way.
-        </p>
-      </div>
     </div>
-  </div>
+</div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/data_summary.html">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/data_summary.html" class="button button--secondary">Load page</a>
+        </p>
+    </div>
 </div>
 
         </div>

--- a/repo_structure.html
+++ b/repo_structure.html
@@ -2,6 +2,14 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    
+    <!-- 
+      http://everypolitician.org/repo_structure.html (this page)
+      is now at http://docs.everypolitician.org/repo_structure.html
+    -->
+    <meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/repo_structure.html">
+    <link rel="canonical" href="http://docs.everypolitician.org/repo_structure.html/" />
+    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">
@@ -10,39 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script src="/javascript/modernizr.js"></script>
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
-    <script src="/javascript/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
-    <script src="/javascript/jquery.select-to-autocomplete.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-2.0.2.min.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-world-mill-en.js"></script>
-    <script src="/javascript/main.js"></script>
-    <meta property="og:title" content="EveryPolitician" />
-    <meta property="og:type" content="article" />
-    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:image:width" content="300" />
-    <meta property="og:site_name" content="EveryPolitician" />
-    <meta property="og:description" content="Data about every national legislature in the world, freely available for you to use.">
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@mysocietyIntl" />
-    <meta name="twitter:title" content="EveryPolitician" />
-    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="twitter:image:height" content="400" />
-    <meta property="twitter:image:width" content="400" />
-    <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />
     <title>EveryPolitician</title>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-660910-34', 'auto');
-      ga('send', 'pageview');
-    </script>
 </head>
 <body>
     <div id="wrapper">
@@ -64,212 +40,30 @@
                 <div class="site-header__navigation site-header__navigation--secondary">
                     <nav role="navigation">
                         <a href="/countries.html">Data</a>
-                        <a href="/about.html">About</a>
+                        <a href="http://docs.everypolitician.org/">Documentation</a>
                     </nav>
                 </div>
             </div>
         </header>
 
         <div class="site-content">
-            <div class="container" id="about">
-  <div class="page-section">
-    <div class="row">
-      <div class="column-one-quarter">
-         <ul class="unstyled-list">
-  <li><a href="about.html">What is EveryPolitician?</a></li>
-  <li><a href="data_summary.html">What’s in the data?</a></li>
-  <li><a href="contribute.html">How to contribute</a></li>
-  <li>Technical details:</li>
-  <li>
-      <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
-        <li><a href="data_structure.html">Data structure</a></li>
-        <li><a href="repo_structure.html">Getting most recent data</a></li>
-        <li><a href="use_the_data.html">Using the data</a></li>
-        <li><a href="submitting.html">How we import data</a></li>
-        <li><a href="scrapers.html">Writing a scraper</a></li>
-      </ul>
-  </li>
-</ul>
-      </div>
-      <div class="column-three-quarters">
-        <h1> Getting the most recent data </h1>
-        <p class="section-intro">
-          If you just browse the site, you’ll find that EveryPolitician links to
-          the most recently updated version of its data files.
-        </p>
-        <p>
-          But if you’re accessing the data programmatically, that might not work
-          nicely for you because the data is hosted on GitHub, which doesn’t
-          serve the right Content-type when your application fetches the data.
-          Instead, <a href="use_the_data.html#rawgit">you should get it from
-          <code>cdn.rawgit.com</code></a> (while you’re there, you should also read
-          our notes on <a href="use_the_data.html">using the data</a> in
-          general). To do that you’ll need to know the URL of the most recent
-          data &mdash; and that means determining the SHA of the git commit
-          that put it there. You get that SHA from the current
-          <code>countries.json</code>, as shown below.
-        </p>
-        
-        <h3>
-          Example URLs
-        </h3>
-        <p>
-          This is what an EveryPolitician data URL looks like:
-        </p>
-        <p class="url-demo-box">
-          <code><span class="url-part-domain">https://<em>domain</em></span><br>
-          &nbsp;&nbsp;
-          /everypolitician/everypolitician-data<br>
-          &nbsp;&nbsp;
-          /<span class="url-part-sha">commit-SHA</span><br>
-          &nbsp;&nbsp;
-          /<span class="url-part-file">path-to-data-file</span></code>
-        </p>
-        <p>
-          You might expect the domain to be <code>https://github.com/</code>, but for
-          your application <a href="/use_the_data.html#rawgit">we recommend you use <code><span class="url-part-domain">https://cdn.rawgit.com</span></code></a>.
-        </p>
-        <p>
-          Wherever you’re getting <code>countries.json</code> from, the <code>data/</code> directory
-          will be a sibling of that.
-        </p>
-        <p>
-          For example: the URLs for the most recent (at time of writing — and
-          that’s <em>already out of date</em>, which neatly demonstrates
-          why you need to know how to determine these SHAs) politicians’
-          data for the UK’s House of Commons legislature, for the 56th term
-          (which started 2015-05-08), look like this:
-        </p>
-        <ul>
-          <li>
-            JSON: <a style="font-size:80%;padding-left:0.5em" href="https://cdn.rawgit.com/everypolitician/everypolitician-data/0b47c0c/data/UK/Commons/ep-popolo-v1.0.json">try it</a>
-            <br>
-            <code><span span class="url-part-domain">https://cdn.rawgit.com</span>/everypolitician/everypolitician-data/<span span class="url-part-sha">0b47c0c</span>/<span class="url-part-file">data/UK/Commons/ep-popolo-v1.0.json</span></code>
-          </li>
-        </ul>
-        <ul>
-          <li>
-            CSV for the term &ldquo;56th Parliament of the United Kingdom&rdquo;:
-            <a style="font-size:80%;padding-left:0.5em" href="https://cdn.rawgit.com/everypolitician/everypolitician-data/0b47c0c/data/UK/Commons/term-56.csv">try it</a>
-            <br>
-            <code><span class="url-part-domain">https://cdn.rawgit.com</span>/everypolitician/everypolitician-data</span>/<span class="url-part-sha">0b47c0c</span>/<span class="url-part-file-alt">data/UK/Commons/term-56.csv</span></code>
-          </li>
-        </ul>
-        <p>
-          ...because the <code>countries.json</code> contained this:
-        </p>
-        <pre>
-{
-  "name": "United Kingdom",
-  "country": "United Kingdom",
-  "code": "GB",
-  "slug": "UK",
-  "legislatures": [
-    {
-      "name": "House of Commons",
-      "slug": "Commons",
-      "sources_directory": "data/UK/Commons/sources",
-      "<strong>popolo</strong>": "<span class="url-part-file">data/UK/Commons/ep-popolo-v1.0.json</span>",
-      "lastmod": "1445087100",
-      "person_count": 1337,
-      "<strong>sha</strong>": "<span class="url-part-sha">0b47c0c</span>",
-      "legislative_periods": [
-        {
-          "id": "term/56",
-          "name": "56th Parliament of the United Kingdom",
-          "start_date": "2015-05-08",
-          "wikidata": "Q21084473",
-          "slug": "56",
-          "<strong>csv</strong>": "<span class="url-part-file-alt">data/UK/Commons/term-56.csv</span>"
-        },
-        {
-          "id": "term/55",
-          "name": "55th Parliament of the United Kingdom",
-          "start_date": "2010-05-06",
-          "end_date": "2015-03-30",
-          ...
-        },
-        ...
-      ]
-    }
-  ]
-}
-        </pre>
-        <h3>
-          Explaining <code>countries.json</code>
-        </h3>
-        <p>
-          EveryPolitician publishes a list in JSON format of
-          all the countries we have data for:
-          <a href="https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/countries.json"><code>countries.json</code></a>.
-          This file includes metadata about what’s available to download.
-        </p>
-        <p>
-          Key fields that <code>countries.json</code> has for each country include:
-        </p>
-        <ul>
-          <li>
-            <code>name</code>:
-            the name of the country to help human-reading of the data
-          </li>
-          <li>
-            <code>slug</code>:
-            the name with spaces replaced by hyphens and punctuation
-            stripped, so suitable for use in URLs and directory names
-          </li>
-          <li>
-            <code>code</code>:
-            the country code (for example, <code>EE</code> for Estonia),
-            which helps with programmatic lookups. We’re using 
-            <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>
-            country codes where possible (with additional ISO 3166-2 
-            three-letter codes where appropriate: for example, <code>GB-WLS</code> for Wales).
-          </li>
-          <li>
-            <code>legislatures</code>:
-            a list of legislatures within this county.  There are lots of
-            ways governments are organised. Some have a single house, others
-            have separate upper and lower chambers. Sometimes a country
-            changes its entire legislative process completely, such as the
-            Council of Deputies in Libya replaced the General National
-            Congress. We separate each of these out individually.
-          </li>
-        </ul>
-        <p>
-          Within the legislatures, in addition to a similar <code>name</code>
-          and <code>slug</code>, these fields help you identify and locate the
-          data you want:
-        </p>
-        <ul>
-          <li>
-            <code>popolo</code>:
-            the path to the Popolo JSON file
-          </li>
-          <li>
-            <code>lastmod</code>:
-            Unix time when the data was last modified
-          </li>
-          <li>
-            <code>sha</code>:
-            git’s hash for the commit in which the data was last modified (see following section)
-          </li>
-          <li>
-            <code>legislative_periods</code>:
-            a list of each of the terms, or periods. Each one of those has these fields:
-            <ul>
-              <li><code>id</code>, <code>name</code>, <code>start_date</code>, and <code>slug</code></li>
-              <li>
-                and also a path (from the directory containing <code>countries.json</code>) to the CSV file containing the data for this term of this legislature
-                (for example, <code>data/Bangladesh/House/term-10.csv</code>)
-              </li>
-            </ul>
-          </li>
-        </ul>    
-      </div>
+            <div class="hero hero--jazzy">
+    <div class="container">
+        <h1>Getting the most recent data</h1>
     </div>
-  </div>
 </div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/repo_structure.html">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/repo_structure.html" class="button button--secondary">Load page</a>
+        </p>
+    </div>
+</div>
+
         </div>
 
         <footer class="site-footer ms-footer">

--- a/scrapers.html
+++ b/scrapers.html
@@ -2,6 +2,14 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    
+    <!-- 
+      http://everypolitician.org/scrapers.html (this page)
+      is now at http://docs.everypolitician.org/scrapers.html
+    -->
+    <meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/scrapers.html">
+    <link rel="canonical" href="http://docs.everypolitician.org/scrapers.html/" />
+    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">
@@ -10,39 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script src="/javascript/modernizr.js"></script>
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
-    <script src="/javascript/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
-    <script src="/javascript/jquery.select-to-autocomplete.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-2.0.2.min.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-world-mill-en.js"></script>
-    <script src="/javascript/main.js"></script>
-    <meta property="og:title" content="EveryPolitician" />
-    <meta property="og:type" content="article" />
-    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:image:width" content="300" />
-    <meta property="og:site_name" content="EveryPolitician" />
-    <meta property="og:description" content="Data about every national legislature in the world, freely available for you to use.">
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@mysocietyIntl" />
-    <meta name="twitter:title" content="EveryPolitician" />
-    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="twitter:image:height" content="400" />
-    <meta property="twitter:image:width" content="400" />
-    <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />
     <title>EveryPolitician</title>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-660910-34', 'auto');
-      ga('send', 'pageview');
-    </script>
 </head>
 <body>
     <div id="wrapper">
@@ -64,230 +40,28 @@
                 <div class="site-header__navigation site-header__navigation--secondary">
                     <nav role="navigation">
                         <a href="/countries.html">Data</a>
-                        <a href="/about.html">About</a>
+                        <a href="http://docs.everypolitician.org/">Documentation</a>
                     </nav>
                 </div>
             </div>
         </header>
 
         <div class="site-content">
-            <div class="container" id="contribute">
-  <div class="page-section">
-    <div class="row">
-      <div class="column-one-quarter">
-         <ul class="unstyled-list">
-  <li><a href="about.html">What is EveryPolitician?</a></li>
-  <li><a href="data_summary.html">What’s in the data?</a></li>
-  <li><a href="contribute.html">How to contribute</a></li>
-  <li>Technical details:</li>
-  <li>
-      <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
-        <li><a href="data_structure.html">Data structure</a></li>
-        <li><a href="repo_structure.html">Getting most recent data</a></li>
-        <li><a href="use_the_data.html">Using the data</a></li>
-        <li><a href="submitting.html">How we import data</a></li>
-        <li><a href="scrapers.html">Writing a scraper</a></li>
-      </ul>
-  </li>
-</ul>
-      </div>
-      <div class="column-three-quarters">
+            <div class="hero hero--jazzy">
+    <div class="container">
         <h1>About writing scrapers</h1>
-        <p class="section-intro">
-          We need to get data into EveryPolitician, and scrapers are a big part
-          of <a href="contribute.html#process">that process</a>. We’re busy
-          writing more, but we’d be very happy if you wrote one for us.
-        </p>
-        <p>
-          Maybe you’ll write the scraper that pulls in the data for your own
-          country. Or maybe you’ll just pick <a
-          href="/needed.html">one that we need</a>
-          (see under: &ldquo;Scraper needed&rdquo;) simply because you’re a
-          kind-hearted, helpful developer. Either way: we love you!
-        </p>
-        <h2>The basic task</h2>
-        <p>
-          The problem your scraper is solving is to convert the source data
-          (typically, but not always, a website or page) into a <a
-          href="/submitting.html">format we can easily import</a>.
-        </p>
-        <p>
-          Also, note that your scraper will not be part of the EveryPolitician
-          codebase &mdash; it’s supporting technology, certainly, but
-          EveryPolitician is really only interested in the data it provides.
-          EveryPolitician doesn’t run scapers; it just consumes their data.
-        </p>
-        <h2>Using morph.io</h2>
-        <p>
-          It’s certainly not mandatory, but if you don’t already have somewhere
-          to run and host your scraper, we encourage you to use <a
-          href="https://morph.io">morph.io</a>. It’s a platform that not only
-          hosts and runs your scraper, but also exposes the data it yields over 
-          an API. This is great for EveryPolitician &mdash; it means we can
-          grab the output from your scraper easily just by knowing its URL. 
-        </p>
-        <p>
-          But it’s also helpful for anyone else who could use that data
-          directly. (This makes sense when you consider that your scraper might
-          be collecting some fields which EveryPolitician discards &mdash; we
-          ignore fields that we’re not intested in storing, because we have a
-          mission to keep the data <a href="data_structure.html">consistent and
-          useful</a> across all the countries; but some of the data we choose 
-          to skip might be useful to someone else.)
-        </p>
-        <h2>
-          Multiple sources: we merge!
-        </h2>
-        <p>
-          It turns out that it’s not uncommon for a country’s politician data
-          to come from <em>more than one source</em>. That’s OK:
-          EveryPolitician expects to have to merge them. A simple example of
-          how this might come about is if the politicians’ membership
-          information (that is: who’s in which political party) is available on
-          one site, but their date-of-birth and gender data is held on another.
-        </p>
-        <p>
-          In such cases, simply write separate scrapers, and let
-          EveryPolitician deal with joining them together. Of course you’ll
-          need to provide some common field or fields that allow the separate
-          sources to be mapped together: often this is the politician’s name.
-          Then we can merge the different data on that. And, yes, we can ease
-          some of the potential pain by using some fuzzy name-matching if the
-          spelling or format is a little wobbly on the different sources.
-        </p>
-        <h2>
-          An example
-        </h2>
-        <p>
-          Since we’ve written a lot of scrapers for this project, we’ve got into
-          a groove, and most of the time we use the same preamble to load the 
-          things we know make this work easier. You can write your scraper in 
-          whatever language you prefer, but we write almost all of ours in Ruby.
-          So in many cases our scraper scripts start like this:
-        </p>
-        <pre><code>#!/bin/env ruby
-# encoding: utf-8
-
-require 'scraperwiki'
-require 'nokogiri'
-require 'pry'
-require 'open-uri/cached'
-</code></pre>
-        <p>
-          The <a href="https://github.com/scraperwiki/scraperwiki-ruby"><code>scraperwiki</code>
-          gem</a> provides access to all the magic of morph.io, including the
-          implicit database that is available for every scraper.
-          The <a href="https://rubygems.org/gems/nokogiri/versions/1.6.6.2"><code>nokogiri gem</code></a>
-          provides powerful HTML parsing tools.
-        </p>
-        <p>
-          There are often two routines in each scraper. It won’t always be
-          the case, but more often than not it’s worked for us:
-        </p>
-        <ul>
-          <li>
-            <p><code>scrape_list(url)</code> &mdash; parses the list of 
-            politicians, isolating each one by name</p>
-          </li>
-          <li>
-            <p><code>scrape_person(url)</code> &mdash; parses the data
-            for each individual politician</p>
-          </li>
-        </ul>
-        <p>
-          Here’s an example of a scraper we’re using to get the data for the US Virgin Islands:
-          <a href="https://github.com/tmtmtmtm/us-virgin-islands-legislature/blob/master/scraper.rb">github.com/tmtmtmtm/us-virgin-islands-legislature/blob/master/scraper.rb</a>.
-        </p>
-        <p>
-          That’s hitting <a href="http://www.legvi.org/index.php/senator-marvin-blyden">www.legvi.org/index.php/senator-marvin-blyden</a>
-          and you can see on the left hand side of that page a list of
-          senators. If you look at the underlying HTML, you’ll see that list is
-          in <code>&lt;div class="mod-inner"&gt;</code> &mdash; specifically
-          the <code>&lt;a&gt;</code> tags within the <code>&lt;li&gt;</code>
-          tags within that. This is isolated with a single call to nokogiri:
-        </p>
-        <pre><code>def scrape_list(url)
-  noko = noko_for(url)
-  <strong>noko.css('.mod-inner li a')</strong>.each do |a|
-    mp_url = URI.join url, a.attr('href')
-    scrape_person(a.text, mp_url)
-  end
-end</code></pre>
-        <p>
-          The data is collected in an hash called <code>data</code>, which is 
-          then saved to the database, using the <code>:id</code> field to 
-          distinguish each record. (As we’re only scraping information for a
-          single period here, that will be unique.) Sometimes there will be an
-          obvious value on the page that can be used as an identifier, but here
-          we construct it from the URL:
-        </p>
-        <pre><code>def scrape_person(name, url)
-  noko = noko_for(url)
-  data = { 
-    id: url.to_s.split("/").last,
-    name: name.sub('Senator ', ''),
-    image: noko.css('img[src*="/Senators/"]/@src').text,
-    source: url.to_s,
-  }
-  data[:image] = URI.join(url, data[:image]).to_s unless data[:image].to_s.empty?
-  ScraperWiki.save_sqlite([:id], data)
-end
-</code></pre>
-
-        <p> 
-          (You might be wondering why we’re gathering so little information
-          here. Didn’t we <a href="/submitting.html">say</a> that we needed
-          things like area, politicial party, etc. too?  Well, that’s because 
-          we’re getting <em>that</em> information from 
-          <a href="https://github.com/tmtmtmtm/us-virgin-islands-legislature-wikipedia/blob/master/scraper.rb">a
-          separate scraper</a>, using the Wikipedia page of the election 
-          results, and then merging the two together as described above.) 
-        </p>
-
-        <h2>
-          Data and terms
-        </h2>
-        <p>
-          The politician’s data is being stored in a table called <code>data</code>
-          (actually this is the default behaviour for morph.io).
-        </p>
-        <p>
-          But EveryPolitician also needs to know the names and dates of the legislative 
-          period(s) / political term(s) that this data applies to. You could simply
-          <em>tell</em> us that, but the best approach is to store them in a 
-          <code>terms</code> table alongside the <code>data</code> table, and then 
-          we can read it automatically.
-        </p>
-        <p>
-          This easy to do, you just provide a the third parameter to the call to 
-          <code>save_sqlite</code>:
-        </p>
-        <p>
-          <code>ScraperWiki.save_sqlite([:id], term_data, 'terms')</code>
-        </p>
-        <p>
-          You can see an explicit example of this in the
-          <a href="https://github.com/tmtmtmtm/tuvalu-parliament-wikipedia/blob/12c8155ae9a40e895b785061ba69d849888cf0b3/scraper.rb#L77-L99">scraper
-          for Tuvalu</a>.
-        </p>
-        <h2>
-          Finally, EveryPolitician collects the data
-        </h2>
-        <p>
-          When you’ve done all the work and scraper is written, EveryPolitician
-          retrieves the data you’ve created by pulling it down from the URL
-          you provide. The actual mechanism is driven by Rake tasks, and doesn’t
-          really affect the way you choose to write your scraper. However, if you
-          look at the <code>instructions.json</code> file that is used to direct
-          EveryPolitician when it collects and merges data from different sources, you can
-          see how it pulls data in from scrapers that effectively map to the different
-          sources. Here’s the
-          <a href="https://github.com/everypolitician/everypolitician-data/blob/master/data/Luxembourg/Chamber/sources/instructions.json">example
-          for Luxembourg</a>.
-      </div>
     </div>
-  </div>
+</div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/scrapers.html">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/scrapers.html" class="button button--secondary">Load page</a>
+        </p>
+    </div>
 </div>
 
         </div>

--- a/submitting.html
+++ b/submitting.html
@@ -2,6 +2,14 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    
+    <!-- 
+      http://everypolitician.org/submitting.html (this page)
+      is now at http://docs.everypolitician.org/submitting.html
+    -->
+    <meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/submitting.html">
+    <link rel="canonical" href="http://docs.everypolitician.org/submitting.html/" />
+    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">
@@ -10,39 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script src="/javascript/modernizr.js"></script>
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
-    <script src="/javascript/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
-    <script src="/javascript/jquery.select-to-autocomplete.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-2.0.2.min.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-world-mill-en.js"></script>
-    <script src="/javascript/main.js"></script>
-    <meta property="og:title" content="EveryPolitician" />
-    <meta property="og:type" content="article" />
-    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:image:width" content="300" />
-    <meta property="og:site_name" content="EveryPolitician" />
-    <meta property="og:description" content="Data about every national legislature in the world, freely available for you to use.">
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@mysocietyIntl" />
-    <meta name="twitter:title" content="EveryPolitician" />
-    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="twitter:image:height" content="400" />
-    <meta property="twitter:image:width" content="400" />
-    <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />
     <title>EveryPolitician</title>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-660910-34', 'auto');
-      ga('send', 'pageview');
-    </script>
 </head>
 <body>
     <div id="wrapper">
@@ -64,193 +40,28 @@
                 <div class="site-header__navigation site-header__navigation--secondary">
                     <nav role="navigation">
                         <a href="/countries.html">Data</a>
-                        <a href="/about.html">About</a>
+                        <a href="http://docs.everypolitician.org/">Documentation</a>
                     </nav>
                 </div>
             </div>
         </header>
 
         <div class="site-content">
-            <div class="container" id="contribute">
-  <div class="page-section">
-    <div class="row">
-      <div class="column-one-quarter">
-         <ul class="unstyled-list">
-  <li><a href="about.html">What is EveryPolitician?</a></li>
-  <li><a href="data_summary.html">What’s in the data?</a></li>
-  <li><a href="contribute.html">How to contribute</a></li>
-  <li>Technical details:</li>
-  <li>
-      <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
-        <li><a href="data_structure.html">Data structure</a></li>
-        <li><a href="repo_structure.html">Getting most recent data</a></li>
-        <li><a href="use_the_data.html">Using the data</a></li>
-        <li><a href="submitting.html">How we import data</a></li>
-        <li><a href="scrapers.html">Writing a scraper</a></li>
-      </ul>
-  </li>
-</ul>
-      </div>
-      <div class="column-three-quarters">
+            <div class="hero hero--jazzy">
+    <div class="container">
         <h1>How We Import Data</h1>
-
-        <p class="section-intro">EveryPolitician exists to share politicians' data &mdash; but
-          before we can put it out, we have to get it in. Our general requirements
-          for importing data are described on this page.
-        </p>
-        <p>
-          Read on if you
-          have a data set you think we could use, or if you're one of
-          the wonderful people who's thinking of
-          <a href="scrapers.html">writing a scraper</a> for us.
-          </p>
-          
-        <p><strong>Our preferred format for data that we are importing is simple comma-separated value (CSV).</strong></p>
-
-        <p>At a minimum this should have fields for:</p>
-
-        <ul>
-          <li><code>id</code>, or <code>identifier__<em>xxx</em></code>: a unique identifier for the politician
-              <p>
-                We add a unique <code>id</code> to every politician we import into EveryPolitician
-                (it's a <a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</a>, and
-                if we know two records are for the same politician, we give them both the same <code>id</code>).
-                If you provide your own <code>id</code>, we can use it to identify the politician
-                <em>during</em> the import, but it will be overwritten with ours.
-              </p>
-              <p>
-                However, if that ID would be useful in the EveryPolitician data
-                because it maps to some external data set, you can make it
-                persist by using the name <code>identifier__<em>xxx</em></code>
-                (note: two underscores), where <code><em>xxx</em></code>
-                indicates the local ID scheme it is from. Our import mechanism
-                treats this like another <code>id</code>, that is, recognises
-                that it's a unique identifier (albeit perhaps with local scope,
-                such as its country).
-              </p>
-              <p>
-                For example, in the UK, parliament allocates a unique ID to all
-                politicians within their own system, called <a
-                href="https://en.wikipedia.org/wiki/Parliamentary_Information_Management_System">PIMS</a>,
-                so when we import that data, we add that ID as
-                <code>identifier__pims</code> in the CSV to import. That will be
-                combined with other IDs from other sources (if any — in the
-                example below, we've added Wikidata too, as
-                <code>identifier__wikidata</code>), and ultimately it appears
-                in the JSON as an (<code>identifier</code>,
-                <code>scheme</code>) pair. Here's an extract from a JSON Popolo
-                file showing how it ultimately appears within a person's entry:
-              </p>
-              <pre>
-"id": "e09079a7-6609-4fe8-93b4-bd499637e130",
-"identifiers": [
-  {
-    "identifier": "4734",
-    "scheme": "pims"
-  },
-  {
-    "identifier": "Q258473",
-    "scheme": "wikidata"
-  }
-],
-              </pre>
-              </p>
-          </li>
-          <li><tt>name</tt>: their name</li>
-          <li><tt>area</tt>: the <a href="https://en.wikipedia.org/wiki/Electoral_district">constituency/district</a> they represent (if appropriate)</li>
-          <li><tt>group</tt>: the <a href="https://en.wikipedia.org/wiki/Parliamentary_group">party or faction</a> they’re part of (if appropriate)</li>
-          <li><tt>term</tt>: the legislative period this membership represents (e.g. ‘19’ for the Nineteenth Assembly)</li>
-          <li><tt>start_date</tt>: if the person joined later than the start of the term</li>
-          <li><tt>end_date</tt>: if they left before the end of the term</li>
-		  <li><tt>source</tt>:
-			  the URL of the main source for this information (for example, if
-			  this data has been scraped from a single page or API call for this person
-			  then that's ideal; but if it's just an entry on a page listing many
-			  politicians, then that page's URL is fine)
-		  </li>
-        </ul>
-
-        <p>If you have data for multiple legislative periods (and the more the
-        better!) these can either be included in the same file, or provided
-        in a single file per per term.</p>
-
-        <p>If someone changed party/faction affilation in the middle of the
-        term, you should include two entries, with the relevant start/end
-        dates set. For example:</p>
-
-        <table border="1">
-          <tr>
-            <th>id</th>
-            <th>name</th>
-            <th>area</th>
-            <th>group</th>
-            <th>term</th>
-            <th>start_date</th>
-            <th>end_date</th>
-            <th>source</th>
-          </tr>
-          <tr>
-            <td>1681</td>
-            <td>Joe Smith</td>
-            <td>Easthill</td>
-            <td>White Party</td>
-            <td>19</td>
-            <td></td>
-            <td>2011-04-14</td>
-            <td>http://example.com/jsmith</td>
-          </tr>
-          <tr>
-            <td>1681</td>
-            <td>Joe Smith</td>
-            <td>Easthill</td>
-            <td>Black Party</td>
-            <td>19</td>
-            <td>2011-04-14</td>
-            <td></td>
-            <td>http://example.com/jsmith</td>
-          </tr>
-        </table> 
-
-        <p>Other fields we can automatically process include:</p>
-
-        <ul>
-          <li><tt>given_name</tt></li>
-          <li><tt>family_name</tt></li>
-          <li><tt>honorific_prefix</tt></li>
-          <li><tt>honorific_suffix</tt></li>
-          <li><tt>patronymic_name</tt></li>
-          <li><tt>sort_name</tt></li>
-          <li><tt>email</tt></li>
-          <li><tt>phone</tt></li>
-          <li><tt>fax</tt></li>
-          <li><tt>cell</tt></li>
-          <li><tt>gender</tt></li>
-          <li><tt>birth_date</tt></li>
-          <li><tt>death_date</tt></li>
-          <li><tt>image</tt></li>
-          <li><tt>summary</tt></li>
-          <li><tt>national_identity</tt></li>
-          <li><tt>twitter</tt></li>
-          <li><tt>facebook</tt></li>
-          <li><tt>blog</tt></li>
-          <li><tt>flickr</tt></li>
-          <li><tt>instagram</tt></li>
-          <li><tt>wikipedia</tt></li>
-          <li><tt>website</tt></li>
-        </ul>
-
-        <p>Ideally you would publish this file somewhere online, and keep it
-        updated with changes, but if that’s too much work, we’ll happily
-        accept a one-time file (perhaps with occasional later updates).
-        Either way, we’re happy to chat first about what will be easiest for
-        both you and us! Just drop us an email to <a
-        href="mailto:team@everypolitician.org">team@everypolitician.org</a>,
-        and let’s get more data released!</p>
-
-      </div>
     </div>
-  </div>
+</div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/submitting.html">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/submitting.html" class="button button--secondary">Load page</a>
+        </p>
+    </div>
 </div>
 
         </div>

--- a/technical.html
+++ b/technical.html
@@ -2,6 +2,14 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    
+    <!-- 
+      http://everypolitician.org/technical.html (this page)
+      is now at http://docs.everypolitician.org/technical.html
+    -->
+    <meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/technical.html">
+    <link rel="canonical" href="http://docs.everypolitician.org/technical.html/" />
+    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">
@@ -10,39 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script src="/javascript/modernizr.js"></script>
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
-    <script src="/javascript/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
-    <script src="/javascript/jquery.select-to-autocomplete.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-2.0.2.min.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-world-mill-en.js"></script>
-    <script src="/javascript/main.js"></script>
-    <meta property="og:title" content="EveryPolitician" />
-    <meta property="og:type" content="article" />
-    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:image:width" content="300" />
-    <meta property="og:site_name" content="EveryPolitician" />
-    <meta property="og:description" content="Data about every national legislature in the world, freely available for you to use.">
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@mysocietyIntl" />
-    <meta name="twitter:title" content="EveryPolitician" />
-    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="twitter:image:height" content="400" />
-    <meta property="twitter:image:width" content="400" />
-    <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />
     <title>EveryPolitician</title>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-660910-34', 'auto');
-      ga('send', 'pageview');
-    </script>
 </head>
 <body>
     <div id="wrapper">
@@ -64,92 +40,28 @@
                 <div class="site-header__navigation site-header__navigation--secondary">
                     <nav role="navigation">
                         <a href="/countries.html">Data</a>
-                        <a href="/about.html">About</a>
+                        <a href="http://docs.everypolitician.org/">Documentation</a>
                     </nav>
                 </div>
             </div>
         </header>
 
         <div class="site-content">
-            <div class="container" id="about">
-  <div class="page-section">
-    <div class="row">
-      <div class="column-one-quarter">
-         <ul class="unstyled-list">
-  <li><a href="about.html">What is EveryPolitician?</a></li>
-  <li><a href="data_summary.html">What’s in the data?</a></li>
-  <li><a href="contribute.html">How to contribute</a></li>
-  <li>Technical details:</li>
-  <li>
-      <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
-        <li><a href="data_structure.html">Data structure</a></li>
-        <li><a href="repo_structure.html">Getting most recent data</a></li>
-        <li><a href="use_the_data.html">Using the data</a></li>
-        <li><a href="submitting.html">How we import data</a></li>
-        <li><a href="scrapers.html">Writing a scraper</a></li>
-      </ul>
-  </li>
-</ul>
-      </div>
-      <div class="column-three-quarters">
+            <div class="hero hero--jazzy">
+    <div class="container">
         <h1>Technical overview</h1>
-        <p class="section-intro">
-          <a href="/">EveryPolitician</a> makes data about politicians
-          available in a consistent manner. If you’re a developer who wants
-          to write code that consumes that data, this page is for you.
-        </p>
-        <h2>The data: CSV or JSON (Popolo)</h2>
-        <p>
-          EveryPolitician publishes the data so you can use it however you want.
-          Use it to power your tools, to drive data-based projects, and to help
-          people know more about who their politicians are. It’s available to
-          download in either <a href="https://en.wikipedia.org/wiki/JSON">JSON</a> or
-          <a href="https://en.wikipedia.org/wiki/Comma-separated_values">CSV</a> formats.
-        </p>
-        <p>
-          Broadly speaking, we provide the complete, rich data in JSON. We use the <a
-          href="http://www.popoloproject.com/">Popolo standard</a> &mdash; if
-          you’re a developer that’s great for you because you get every
-          detail of the data. The CSV data is simpler &mdash; it’s ideal for
-          dropping into a spreadsheet or displaying in a web page.
-        </p>
-        <p>
-          For example, if someone's name changes during a period (eg. if
-          they get married), the later version will be presented as their
-          name in the CSV. But if you dive into the JSON data you’re be able
-          to see the dates when this new name applied, and what it was
-          before. You can think of the JSON as the full data in its raw
-          form, and the CSVs as the refined, more pragmatic version.
-        </p>
-        <p>
-          EveryPolitician doesn’t provide an API for you to query the data
-          &mdash; we simply make the whole lot available for download, and if you
-          need to be selective about which bits to use, you can do that
-          processing at your end. 
-        </p>
-        <p>
-          However, we <em>do</em> slice the CSV data up into separate files
-          for each legislative period for a country.  We use these
-          "parliamentary terms" because pretty much every legislature in the
-          world can be broken down in this way, and applications often only
-          really want to know data about the people currently in these
-          positions. For many countries we currently only <em>have</em> data
-          for the current period, but we‘re very keen to also add older,
-          "historic" data too.
-        </p>
-
-        <p>
-          Read more about:
-          <ul>
-            <li><a href="/data_structure.html">the data structure</a></li>
-            <li><a href="/repo_structure.html">the repository structure</a></li>
-            <li><a href="/data_summary.html">what’s in the data</a></li>
-          </ul>
-        </p>
-      </div>
     </div>
-  </div>
+</div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/technical.html">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/technical.html" class="button button--secondary">Load page</a>
+        </p>
+    </div>
 </div>
 
         </div>

--- a/use_the_data.html
+++ b/use_the_data.html
@@ -2,6 +2,14 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    
+    <!-- 
+      http://everypolitician.org/use_the_data.html (this page)
+      is now at http://docs.everypolitician.org/use_the_data.html
+    -->
+    <meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/use_the_data.html">
+    <link rel="canonical" href="http://docs.everypolitician.org/use_the_data.html/" />
+    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">
@@ -10,39 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script src="/javascript/modernizr.js"></script>
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
-    <script src="/javascript/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
-    <script src="/javascript/jquery.select-to-autocomplete.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-2.0.2.min.js"></script>
-    <script src="/javascript/jquery-jvectormap/jquery-jvectormap-world-mill-en.js"></script>
-    <script src="/javascript/main.js"></script>
-    <meta property="og:title" content="EveryPolitician" />
-    <meta property="og:type" content="article" />
-    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:image:width" content="300" />
-    <meta property="og:site_name" content="EveryPolitician" />
-    <meta property="og:description" content="Data about every national legislature in the world, freely available for you to use.">
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@mysocietyIntl" />
-    <meta name="twitter:title" content="EveryPolitician" />
-    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
-    <meta property="twitter:image:height" content="400" />
-    <meta property="twitter:image:width" content="400" />
-    <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />
     <title>EveryPolitician</title>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-660910-34', 'auto');
-      ga('send', 'pageview');
-    </script>
 </head>
 <body>
     <div id="wrapper">
@@ -64,251 +40,28 @@
                 <div class="site-header__navigation site-header__navigation--secondary">
                     <nav role="navigation">
                         <a href="/countries.html">Data</a>
-                        <a href="/about.html">About</a>
+                        <a href="http://docs.everypolitician.org/">Documentation</a>
                     </nav>
                 </div>
             </div>
         </header>
 
         <div class="site-content">
-            <div class="container" id="contribute">
-  <div class="page-section">
-    <div class="row">
-      <div class="column-one-quarter">
-         <ul class="unstyled-list">
-  <li><a href="about.html">What is EveryPolitician?</a></li>
-  <li><a href="data_summary.html">What’s in the data?</a></li>
-  <li><a href="contribute.html">How to contribute</a></li>
-  <li>Technical details:</li>
-  <li>
-      <ul class="unstyled-list">
-        <a href="technical.html">CSV and JSON</a></li>
-        <li><a href="data_structure.html">Data structure</a></li>
-        <li><a href="repo_structure.html">Getting most recent data</a></li>
-        <li><a href="use_the_data.html">Using the data</a></li>
-        <li><a href="submitting.html">How we import data</a></li>
-        <li><a href="scrapers.html">Writing a scraper</a></li>
-      </ul>
-  </li>
-</ul>
-      </div>
-      <div class="column-three-quarters">
+            <div class="hero hero--jazzy">
+    <div class="container">
         <h1>Use EveryPolitician data</h1>
-        <p class="section-intro">
-          We gather together all this lovely data, curate it, and make it
-          reliably available... so you can use it. Here’s the bare bones of how
-          your application can get it.
-        </p>
-        <p>
-          This page is for you if you’re a developer who is planning on
-          building something wonderful or brilliant with the data we have on
-          your country’s politicians. It tells you how to get the data and,
-          broadly, how it’s structured (spoiler: CSV or Popolo JSON).
-        </p>
-        <p>
-          We believe that by making this data available in consistent and
-          useful formats, if you write something neat that uses, for example,
-          the data for your country’s politicians, and open it up under a free
-          software open source license... then other people will be able to
-          adapt what you’ve done to run in their country too. That works
-          because their data will be formatted the same way that yours is:
-          that’s our side of the deal.
-        </p>
-        <h2>
-          How to find what data we’ve got for you
-        </h2>
-        <p>
-          Humans look at the <a href="countries.html">interactive map</a>. But
-          you’re a developer: you look in
-          <code><a href="https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/countries.json">countries.json</a></code>.
-        </p>
-        <p>
-          That’s because <code>countries.json</code> is effectively
-          EveryPolitician’s index. It contains a simple JSON array of objects,
-          one for every country we’ve got data for. These contain identifying
-          fields (like name and country code) as well as metadata for each
-          legislature within those countries. From <code>countries.json</code>
-          you can <a href="repo_structure.html">construct the URLs</a> of the
-          files that contain the data you want.
-        </p>
-        <p>
-          Every time we change any of the data, we update
-          <code>countries.json</code>. See <a
-          href="repo_structure.html">getting the most recent data</a> for
-          details about using this crucial file.
-        </p>
-        <h2>
-          Three approaches to getting the data
-        </h2>
-        <p>
-          You’re going to write the code. All you need is the data.
-        </p>
-        <p>
-          But before you go any further, we want you to think about
-          <em>how</em> you’re going to be getting it. We deliberately
-          <em>don’t</em> provide an API — instead, we make the data available
-          and encourage you to adopt a good policy on how and when you actually
-          go about getting it. There are various approaches, depending on your
-          need:
-        </p>
-        <ul>
-          <li><a href="#download-it-once">download it once, never worry again</a></li>
-          <li><a href="#download-it-again">download it periodically</a></li>
-          <li><a href="#download-triggered-by-event">download it whenever it changes: event-driven</a></li>
-        </ul>
-        <a name="download-it-once"></a>
-        <h3>
-          Download it once, never worry again
-        </h3>
-        <p>
-          If you’re doing a one-off — maybe building an infographic or plotting
-          a graph for a printed magazine — this could work for you. But
-          remember that <em>political data changes</em> — elections happen,
-          politicians die, errors get corrected. So if it matters that the data
-          you’re using is timely, and these sort of changes should be reflected
-          in it, then it’s probably better to use of the following approaches.
-        </p>
-        <a name="download-it-again"></a>
-        <h3>
-          Download it periodically, so you keep up to date
-        </h3>
-        <p>
-          You can download the data as often as makes sense for your
-          application — perhaps every day, or every week, or whenever you press
-          a button. This means your code will often be updating existing data,
-          as well as adding new data. You need to consider things like: what
-          happens if a politician’s name changes? Someone is removed? A whole
-          new group of politicians is elected?
-        </p>
-        <p>
-          Once you’ve got this working, you can safely download the data
-          whenever you know it has changed... or even automate it — for
-          example, setting up a task to pull down the latest data every night.
-        </p>
-        <a name="download-triggered-by-event"></a>
-        <h3>
-          Download it whenever it changes: event-driven
-        </h3>
-        <p>
-          We run a service that will notify you whenever the data is updated.
-        </p>
-        <p>
-          You can register your application with the <a
-          href="https://everypolitician-app-manager.herokuapp.com/">EveryPolitician
-          app manager</a> (you’ll need to login with your GitHub account)
-          and whenever the data changes we’ll make a POST request to the URL
-          you nominate. This operates like a webhook: your application can run
-          any code in response to the EveryPolitician data having been updated.
-          Typically this would be to pull down the latest data files.
-        </p>
-        <p>
-          We use this event-triggered mechanism for the <a
-          href="http://www.gender-balance.org/">Gender Balance</a> application.
-          It’s registered with the app manager, so it is alerted when there is
-          new data available to download — basically, it can keep itself
-          up-to-date. So whether there’s an election in Sweden or a politician
-          in Thailand changes their name, Gender Balance will incorporate the
-          change as soon as EveryPolitician has the data.
-        </p>
-        <h2>
-          Pick a format
-        </h2>
-        <p>
-          The data itself is available in two formats. Which one you want will
-          depend on what you’re trying to do with it.
-        </p>
-        <ul>
-          <li><a href="#csv-data">CSV data</a> for straightforward data for a given term</li>
-          <li><a href="#json-data">Popolo JSON data</a> for full structured data</li>
-        </ul>
-        <a name="csv-data"></a>
-        <h3>
-          CSV data
-        </h3>
-        <p>
-          We make the data available as CSV (comma separated values) because
-          it’s just so <em>useful</em>. If you just want the basic data, it
-          might also be the simplest way for you to absorb it. For any given
-          legislature we slice the data up into separate CSV files for each
-          legislative period, or “term”.
-        </p>
-        <p>
-          The disadvantage of the CSV format is it can’t be as rich, because,
-          by definition, it can’t easily represent structure. So that’s what
-          the JSON is for.
-        </p>
-        <a name="json-data"></a>
-        <h3>
-          Popolo JSON data
-        </h3>
-        <p>
-          <a href="http://www.popoloproject.com/">Popolo is an open
-          standard</a> for expressing political data — exactly for the kind of
-          thing we’re doing here. So we provide our data in JSON format too,
-          complying with Popolo standard. These are the same politicians as in
-          the CSV of course (we generate both the CSV and JSON anew every time
-          anything changes, keeping them perfectly in sync), but the data is
-          richer. So, unlike the CSV which is sliced by terms, if you pull down
-          the JSON data you’ll be getting <em>all</em> the data for all the
-          politicians across all the terms.
-        </p>
-        <p>
-          If you’re doing anything which needs this sort of richness, grab the
-          JSON data and use your favourite JSON library to jump right into
-          having structured data in your application.
-        </p>
-        <a name="rawgit"></a>
-        <h2>
-          Where to get it from: <code>cdn.rawgit.com</code>
-        </h2>
-        <p>
-          The EveryPolitician data is published on GitHub, which means the raw
-          files are automatically available from
-          <code>raw.githubusercontent.com</code> too. But you can also get it
-          from <code>cdn.rawgit.com</code> instead. Here’s why that might be
-          useful.
-        </p>
-        <p>
-          In order to discourage the use of its repos for static hosting,
-          GitHub itself doesn’t serve the data with the right MIME-type content
-          headers. This works passably well for humans (your web browser thinks
-          it’s getting plain text), but won’t work properly with your
-          application if it needs the correct Content-type. This is likely to
-          matter <strong>if you’re making client-side AJAX requests</strong>,
-          for example.
-        </p>
-        <p>
-          So instead, we encourage you to get the data from <a
-          href="https://rawgit.com/faq">RawGit</a>. RawGit acts as a caching
-          proxy. If you ask it for a file it will get it from GitHub on your
-          behalf, but significantly when it sends it back to you it sets the
-          correct Content-Type. Of course, it also caches it so if you or
-          anyone else asks for it again, GitHub won’t be troubled.
-        </p>
-        <p>
-          This works because those files are static. And they’re static because
-          every RawGit URL must have a commit SHA in it — that is, you’re
-          explicitly referring to a specific file in EveryPolitician’s repo.
-          Remember <code>countries.json</code>? That’s why we put the
-          <em>latest commit SHA</em> in there.
-        </p>
-        <h3>
-          Use <code>countries.json</code> to construct the latest data URLs
-        </h3>
-        <p>
-          So, when you’re grabbing data programmatically from EveryPolitician,
-          the right way to do it is to construct a URL for the
-          <code>cdn.rawgit.com</code> domain using the SHA and path information
-          that’s in <code>countries.json</code>.
-        </p>
-        <div class="process-boxes">
-          <div class="step-1">
-            <a href="repo_structure.html">Here’s how to construct the URL</a>
-          </div>
-        </div>
     </div>
+</div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/use_the_data.html">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/use_the_data.html" class="button button--secondary">Load page</a>
+        </p>
     </div>
-  </div>
 </div>
 
         </div>


### PR DESCRIPTION
@tmtmtmtm || @chrismytton -- requesting sanity check on this. I think it's sound but want second opinion to check my reasoning, described below, thanks :-)

Closes everypolitician/everypolitician#437

We've moved the documentation pages over to http://docs.everypolitician.org
but the old ones remain in this repo; there might be some incoming links
to them, so rather than just deleting, I've replaced them with placeholder
pages with `meta refresh` tags in their headers.

This isn't a great solution but it's the best we can currently do on
GitHub Pages (since there's no .htaccess or request-level redirect
available). Note that I haven't used GitHub's `redirect-from` capability
because all that's doing is injecting such `meta` HTTP-refresh tags anyway.
Their solution is handy if you're generating pages from Jekyll but as
we're not it's just as easy to drop these placeholders in. Maybe I
could have seperated these pages out as a template but that seems
overkill since they're deprecated anyway..

Note that all the pages redirect to their identically-named file
on docs.everypolitician.org _except_ `about.html` which redirects to
`index.html` on that subdomain.

Also, in case it's not clear, some of these old pages' text was out
of date (of course) which is why I've replaced their contents with
placeholders (lifted from 404.html).
